### PR TITLE
Avoid depending on typing_extensions.

### DIFF
--- a/src/django_enum/utils.py
+++ b/src/django_enum/utils.py
@@ -16,9 +16,8 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    get_args,
 )
-
-from typing_extensions import get_args
 
 __all__ = [
     "choices",

--- a/tests/edit_tests/edits/_1.py
+++ b/tests/edit_tests/edits/_1.py
@@ -1,5 +1,4 @@
 import typing as t
-from typing_extensions import Annotated
 
 from django.db import models
 from enum_properties import Symmetric
@@ -18,8 +17,8 @@ class MigrationTester(models.Model):
         THREE = 2, "Three"
 
     class Color(TextChoices):
-        rgb: Annotated[t.Tuple[int, int, int], Symmetric()]
-        hex: Annotated[str, Symmetric(case_fold=True)]
+        rgb: t.Annotated[t.Tuple[int, int, int], Symmetric()]
+        hex: t.Annotated[str, Symmetric(case_fold=True)]
 
         RED = "R", "Red", (1, 0, 0), "ff0000"
         GREEN = "G", "Green", (0, 1, 0), "00ff00"

--- a/tests/edit_tests/edits/_10.py
+++ b/tests/edit_tests/edits/_10.py
@@ -1,5 +1,4 @@
 import typing as t
-from typing_extensions import Annotated
 
 from django.db import models
 from enum_properties import Symmetric
@@ -18,8 +17,8 @@ class MigrationTester(models.Model):
         C = "C", "Three"
 
     class Color(TextChoices):
-        rgb: Annotated[t.Tuple[int, int, int], Symmetric()]
-        hex: Annotated[str, Symmetric(case_fold=True)]
+        rgb: t.Annotated[t.Tuple[int, int, int], Symmetric()]
+        hex: t.Annotated[str, Symmetric(case_fold=True)]
 
         RED = "R", "Red", (1, 0, 0), "ff0000"
         GREEN = "G", "Green", (0, 1, 0), "00ff00"

--- a/tests/edit_tests/edits/_2.py
+++ b/tests/edit_tests/edits/_2.py
@@ -1,5 +1,4 @@
 import typing as t
-from typing_extensions import Annotated
 
 from django.db import models
 from enum_properties import Symmetric
@@ -20,8 +19,8 @@ class MigrationTester(models.Model):
 
     # unchanged
     class Color(TextChoices):
-        rgb: Annotated[t.Tuple[int, int, int], Symmetric()]
-        hex: Annotated[str, Symmetric(case_fold=True)]
+        rgb: t.Annotated[t.Tuple[int, int, int], Symmetric()]
+        hex: t.Annotated[str, Symmetric(case_fold=True)]
 
         RED = "R", "Red", (1, 0, 0), "ff0000"
         GREEN = "G", "Green", (0, 1, 0), "00ff00"

--- a/tests/edit_tests/edits/_3.py
+++ b/tests/edit_tests/edits/_3.py
@@ -1,5 +1,4 @@
 import typing as t
-from typing_extensions import Annotated
 
 from django.db import models
 from enum_properties import Symmetric
@@ -20,8 +19,8 @@ class MigrationTester(models.Model):
 
     # remove black
     class Color(TextChoices):
-        rgb: Annotated[t.Tuple[int, int, int], Symmetric()]
-        hex: Annotated[str, Symmetric(case_fold=True)]
+        rgb: t.Annotated[t.Tuple[int, int, int], Symmetric()]
+        hex: t.Annotated[str, Symmetric(case_fold=True)]
 
         # name   value   label       rgb       hex
         RED = "R", "Red", (1, 0, 0), "ff0000"

--- a/tests/edit_tests/edits/_4.py
+++ b/tests/edit_tests/edits/_4.py
@@ -1,5 +1,4 @@
 import typing as t
-from typing_extensions import Annotated
 
 from django.db import models
 from enum_properties import Symmetric
@@ -20,8 +19,8 @@ class MigrationTester(models.Model):
 
     # change enumeration names
     class Color(TextChoices):
-        rgb: Annotated[t.Tuple[int, int, int], Symmetric()]
-        hex: Annotated[str, Symmetric(case_fold=True)]
+        rgb: t.Annotated[t.Tuple[int, int, int], Symmetric()]
+        hex: t.Annotated[str, Symmetric(case_fold=True)]
 
         # name   value   label       rgb       hex
         RD = "R", "Red", (1, 0, 0), "ff0000"

--- a/tests/edit_tests/edits/_5.py
+++ b/tests/edit_tests/edits/_5.py
@@ -1,5 +1,4 @@
 import typing as t
-from typing_extensions import Annotated
 
 from django.db import models
 from enum_properties import Symmetric
@@ -20,8 +19,8 @@ class MigrationTester(models.Model):
 
     # change enumeration names
     class Color(TextChoices):
-        rgb: Annotated[t.Tuple[int, int, int], Symmetric()]
-        hex: Annotated[str, Symmetric(case_fold=True)]
+        rgb: t.Annotated[t.Tuple[int, int, int], Symmetric()]
+        hex: t.Annotated[str, Symmetric(case_fold=True)]
 
         # name   value   label       rgb       hex
         RD = "R", "Red", (1, 0, 0), "ff0000"

--- a/tests/edit_tests/edits/_6.py
+++ b/tests/edit_tests/edits/_6.py
@@ -1,5 +1,4 @@
 import typing as t
-from typing_extensions import Annotated
 
 from django.db import models
 from enum_properties import Symmetric
@@ -21,8 +20,8 @@ class MigrationTester(models.Model):
 
     # change enumeration names
     class Color(TextChoices):
-        rgb: Annotated[t.Tuple[int, int, int], Symmetric()]
-        hex: Annotated[str, Symmetric(case_fold=True)]
+        rgb: t.Annotated[t.Tuple[int, int, int], Symmetric()]
+        hex: t.Annotated[str, Symmetric(case_fold=True)]
 
         # name   value   label       rgb       hex
         RD = "R", "Red", (1, 0, 0), "ff0000"

--- a/tests/edit_tests/edits/_7.py
+++ b/tests/edit_tests/edits/_7.py
@@ -1,5 +1,4 @@
 import typing as t
-from typing_extensions import Annotated
 
 from django.db import models
 from enum_properties import Symmetric
@@ -13,8 +12,8 @@ class MigrationTester(models.Model):
 
     # no change
     class Color(TextChoices):
-        rgb: Annotated[t.Tuple[int, int, int], Symmetric()]
-        hex: Annotated[str, Symmetric(case_fold=True)]
+        rgb: t.Annotated[t.Tuple[int, int, int], Symmetric()]
+        hex: t.Annotated[str, Symmetric(case_fold=True)]
 
         # name   value   label       rgb       hex
         RD = "R", "Red", (1, 0, 0), "ff0000"

--- a/tests/edit_tests/edits/_8.py
+++ b/tests/edit_tests/edits/_8.py
@@ -1,5 +1,4 @@
 import typing as t
-from typing_extensions import Annotated
 
 from django.db import models
 from enum_properties import Symmetric
@@ -19,8 +18,8 @@ class MigrationTester(models.Model):
         C = "C", "Three"
 
     class Color(TextChoices):
-        rgb: Annotated[t.Tuple[int, int, int], Symmetric()]
-        hex: Annotated[str, Symmetric(case_fold=True)]
+        rgb: t.Annotated[t.Tuple[int, int, int], Symmetric()]
+        hex: t.Annotated[str, Symmetric(case_fold=True)]
 
         RED = "R", "Red", (1, 0, 0), "ff0000"
         GREEN = "G", "Green", (0, 1, 0), "00ff00"

--- a/tests/edit_tests/edits/_9.py
+++ b/tests/edit_tests/edits/_9.py
@@ -1,5 +1,4 @@
 import typing as t
-from typing_extensions import Annotated
 
 from django.db import models
 from enum_properties import Symmetric
@@ -18,8 +17,8 @@ class MigrationTester(models.Model):
         C = "C", "Three"
 
     class Color(TextChoices):
-        rgb: Annotated[t.Tuple[int, int, int], Symmetric()]
-        hex: Annotated[str, Symmetric(case_fold=True)]
+        rgb: t.Annotated[t.Tuple[int, int, int], Symmetric()]
+        hex: t.Annotated[str, Symmetric(case_fold=True)]
 
         RED = "R", "Red", (1, 0, 0), "ff0000"
         GREEN = "G", "Green", (0, 1, 0), "00ff00"

--- a/tests/enum_prop/enums.py
+++ b/tests/enum_prop/enums.py
@@ -1,7 +1,6 @@
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 import typing as t
-from typing_extensions import Annotated
 from django.db.models import IntegerChoices as DjangoIntegerChoices
 from django.db.models import TextChoices as DjangoTextChoices
 from django.utils.translation import gettext as _
@@ -26,7 +25,7 @@ class DJTextEnum(DjangoTextChoices):
 class TextEnum(TextChoices):
     version: int
     help: str
-    aliases: Annotated[t.List[str], Symmetric(case_fold=True)]
+    aliases: t.Annotated[t.List[str], Symmetric(case_fold=True)]
 
     VALUE1 = (
         "V1",
@@ -59,7 +58,7 @@ class TextEnum(TextChoices):
 
 
 class Constants(FloatChoices):
-    symbol: Annotated[str, Symmetric()]
+    symbol: t.Annotated[str, Symmetric()]
 
     PI = 3.14159265358979323846264338327950288, "Pi", "π"
     e = 2.71828, "Euler's Number", "e"
@@ -103,7 +102,7 @@ class BigPosIntEnum(IntegerChoices):
 
 
 class BigIntEnum(IntegerChoices):
-    pos: Annotated[BigPosIntEnum, Symmetric()]
+    pos: t.Annotated[BigPosIntEnum, Symmetric()]
     help: str
 
     VAL0 = (
@@ -123,7 +122,7 @@ class BigIntEnum(IntegerChoices):
 
 
 class DateEnum(EnumProperties):
-    label: Annotated[str, Symmetric()]
+    label: t.Annotated[str, Symmetric()]
 
     BRIAN = date(1984, 8, 7), "Brian"
     EMMA = date(1989, 7, 27), "Emma"
@@ -148,7 +147,7 @@ class DateEnum(EnumProperties):
 
 
 class DateTimeEnum(EnumProperties):
-    label: Annotated[str, Symmetric()]
+    label: t.Annotated[str, Symmetric()]
 
     ST_HELENS = datetime(1980, 5, 18, 8, 32, 0), "Mount St. Helens"
     PINATUBO = datetime(1991, 6, 15, 20, 9, 0), "Pinatubo"
@@ -173,7 +172,7 @@ class DateTimeEnum(EnumProperties):
 
 
 class TimeEnum(EnumProperties):
-    label: Annotated[str, Symmetric()]
+    label: t.Annotated[str, Symmetric()]
 
     COB = time(17, 0, 0), "Close of Business"
     LUNCH = time(12, 30, 0), "Lunch"
@@ -198,7 +197,7 @@ class TimeEnum(EnumProperties):
 
 
 class DurationEnum(EnumProperties):
-    label: Annotated[str, Symmetric(case_fold=True)]
+    label: t.Annotated[str, Symmetric(case_fold=True)]
 
     DAY = timedelta(days=1), "DAY"
     WEEK = timedelta(weeks=1), "WEEK"
@@ -223,7 +222,7 @@ class DurationEnum(EnumProperties):
 
 
 class DecimalEnum(EnumProperties):
-    label: Annotated[str, Symmetric(case_fold=True)]
+    label: t.Annotated[str, Symmetric(case_fold=True)]
 
     ONE = Decimal("0.99"), "One"
     TWO = Decimal("0.999"), "Two"
@@ -252,10 +251,10 @@ class DecimalEnum(EnumProperties):
 
 
 class PrecedenceTest(IntegerChoices):
-    prop1: Annotated[t.Union[int, str], Symmetric()]
-    prop2: Annotated[float, Symmetric()]
-    prop3: Annotated[str, Symmetric(case_fold=False)]
-    prop4: Annotated[t.List[t.Union[str, float, int]], Symmetric(case_fold=True)]
+    prop1: t.Annotated[t.Union[int, str], Symmetric()]
+    prop2: t.Annotated[float, Symmetric()]
+    prop3: t.Annotated[str, Symmetric(case_fold=False)]
+    prop4: t.Annotated[t.List[t.Union[str, float, int]], Symmetric(case_fold=True)]
 
     P1 = 0, "Precedence 1", 3, 0.1, _("First"), ["0.4", "Fourth", 1]
     P2 = 1, "Precedence 2", 2, 0.2, _("Second"), ["0.3", "Third", 2]
@@ -287,7 +286,7 @@ class CarrierFrequency(FlagChoices):
 class GNSSConstellation(FlagChoices):
     _symmetric_builtins_ = ["name", s("label", Symmetric(case_fold=True))]
 
-    country: Annotated[str, Symmetric()]
+    country: t.Annotated[str, Symmetric()]
     satellites: int
     frequencies: CarrierFrequency
 
@@ -338,7 +337,7 @@ class ExternEnum(IntEnumProperties):
     are supported.
     """
 
-    label: Annotated[str, Symmetric(case_fold=True)]
+    label: t.Annotated[str, Symmetric(case_fold=True)]
 
     ONE = 1, "One"
     TWO = 2, "Two"
@@ -346,7 +345,7 @@ class ExternEnum(IntEnumProperties):
 
 
 class SmallPositiveFlagEnum(FlagChoices):
-    number: Annotated[int, Symmetric()]
+    number: t.Annotated[int, Symmetric()]
 
     ONE = 2**10, "One", 1
     TWO = 2**11, "Two", 2
@@ -356,7 +355,7 @@ class SmallPositiveFlagEnum(FlagChoices):
 
 
 class PositiveFlagEnum(FlagChoices):
-    number: Annotated[int, Symmetric()]
+    number: t.Annotated[int, Symmetric()]
 
     ONE = 2**26, "One", 1
     TWO = 2**27, "Two", 2
@@ -366,7 +365,7 @@ class PositiveFlagEnum(FlagChoices):
 
 
 class BigPositiveFlagEnum(FlagChoices):
-    version: Annotated[float, Symmetric()]
+    version: t.Annotated[float, Symmetric()]
 
     ONE = 2**58, "One", 1.1
     TWO = 2**59, "Two", 2.2
@@ -376,7 +375,7 @@ class BigPositiveFlagEnum(FlagChoices):
 
 
 class ExtraBigPositiveFlagEnum(FlagChoices):
-    version: Annotated[float, Symmetric()]
+    version: t.Annotated[float, Symmetric()]
 
     ONE = 2**61, "One", 1.1
     TWO = 2**62, "Two", 2.2

--- a/tests/enum_prop/models.py
+++ b/tests/enum_prop/models.py
@@ -1,7 +1,6 @@
 from django.db import models
 from django.urls import reverse
 from enum_properties import StrEnumProperties, IntEnumProperties, Symmetric
-from typing_extensions import Annotated
 import typing as t
 
 from django_enum import EnumField
@@ -148,9 +147,9 @@ class MyModel(models.Model):
         THREE = 3, "Three"
 
     class Color(StrEnumProperties):
-        label: Annotated[str, Symmetric()]
-        rgb: Annotated[t.Tuple[int, int, int], Symmetric()]
-        hex: Annotated[str, Symmetric(case_fold=True)]
+        label: t.Annotated[str, Symmetric()]
+        rgb: t.Annotated[t.Tuple[int, int, int], Symmetric()]
+        hex: t.Annotated[str, Symmetric(case_fold=True)]
 
         # name   value   label       rgb       hex
         RED = "R", "Red", (1, 0, 0), "ff0000"

--- a/tests/examples/models/properties.py
+++ b/tests/examples/models/properties.py
@@ -2,7 +2,6 @@
 import typing as t
 from django.db import models
 from enum_properties import Symmetric, StrEnumProperties
-from typing_extensions import Annotated
 from django_enum import EnumField
 
 
@@ -11,8 +10,8 @@ class PropertyExample(models.Model):
     class Color(StrEnumProperties):
 
         label: str
-        rgb: Annotated[t.Tuple[int, int, int], Symmetric()]
-        hex: Annotated[str, Symmetric(case_fold=True)]
+        rgb: t.Annotated[t.Tuple[int, int, int], Symmetric()]
+        hex: t.Annotated[str, Symmetric(case_fold=True)]
 
         # fmt: off
         # name value label       rgb       hex

--- a/tests/examples/models/properties_choices.py
+++ b/tests/examples/models/properties_choices.py
@@ -2,7 +2,6 @@
 import typing as t
 from django.db import models
 from enum_properties import Symmetric
-from typing_extensions import Annotated
 from django_enum import EnumField
 from django_enum.choices import TextChoices
 
@@ -11,8 +10,8 @@ class ChoicesWithProperties(models.Model):
     class Color(TextChoices):
 
         # label is added as a symmetric property by the base class
-        rgb: Annotated[t.Tuple[int, int, int], Symmetric()]
-        hex: Annotated[str, Symmetric(case_fold=True)]
+        rgb: t.Annotated[t.Tuple[int, int, int], Symmetric()]
+        hex: t.Annotated[str, Symmetric(case_fold=True)]
 
         # fmt: off
         # name value label       rgb       hex

--- a/tests/examples/models/text_choices.py
+++ b/tests/examples/models/text_choices.py
@@ -1,7 +1,6 @@
 # flake8: noqa
 import typing as t
 from django.db import models
-from typing_extensions import Annotated
 from django_enum import EnumField
 from django_enum.choices import TextChoices
 from enum_properties import Symmetric, symmetric
@@ -12,8 +11,8 @@ class TextChoicesExample(models.Model):
     class Color(TextChoices):
 
         # no need to specify label because it is built in
-        rgb: Annotated[t.Tuple[int, int, int], Symmetric()]
-        hex: Annotated[str, Symmetric(case_fold=True)]
+        rgb: t.Annotated[t.Tuple[int, int, int], Symmetric()]
+        hex: t.Annotated[str, Symmetric(case_fold=True)]
 
         # fmt: off
         # name value label       rgb       hex


### PR DESCRIPTION
While type hints utilize `typing_extensions`, django-enum does not include typing_extensions as a dependency library. Even if installed, typing_extensions will not be automatically installed.

The only elements from typing_extensions used are `get_args` and `Annotated`, but in Python 3.9, both are available in the `typing` module.
Since django-enum requires Python 3.9 or higher, there seems to be no need to specifically use typing_extensions.