### PR TITLE
Fix `has_any`, `has_all` lookups to remove incorrect 0 case, switch `>` to `<>`

### DIFF
--- a/src/django_enum/query.py
+++ b/src/django_enum/query.py
@@ -3,31 +3,28 @@ Specialized has_any and has_all query lookups for flag enumerations.
 """
 
 # from django.core.exceptions import FieldError
-from django.db.models.lookups import Exact, Lookup
+from django.db.models.lookups import Lookup
 
 # from django_enum.utils import get_set_bits
 
 
-class HasAllFlagsLookup(Exact):
+class HasAllFlagsLookup(Lookup):
     """
-    Extend Exact lookup to support lookup on has all flags. This lookup bitwise
-    ANDs the column with the lookup value and checks that the result is equal
-    to the lookup value.
+    Query whether the left-hand side has all the bit flags on the right-hand
+    side. This lookup bitwise ANDs the left-hand side with the right-hand side
+    and checks that the result is equal to the right-hand side.
     """
 
     lookup_name = "has_all"
 
-    def process_lhs(self, compiler, connection, lhs=None):
-        lhs_sql, lhs_params = super().process_lhs(compiler, connection, lhs)
-        rhs_sql, rhs_params = super().process_rhs(compiler, connection)
-        if self.rhs:
-            return (
-                "BITAND(%s, %s)" if connection.vendor == "oracle" else "%s & %s"
-            ) % (lhs_sql, rhs_sql), [*lhs_params, *rhs_params]
-        return lhs_sql, lhs_params
-
-    def get_rhs_op(self, connection, rhs):
-        return connection.operators["exact"] % rhs  # type: ignore[attr-defined]
+    def as_sql(self, compiler, connection):
+        lhs_sql, lhs_params = self.process_lhs(compiler, connection)
+        rhs_sql, rhs_params = self.process_rhs(compiler, connection)
+        return (
+            f"BITAND({lhs_sql}, {rhs_sql}) = {rhs_sql}"
+            if connection.vendor == "oracle"
+            else f"{lhs_sql} & {rhs_sql} = {rhs_sql}"
+        ), [*lhs_params, *rhs_params, *rhs_params]
 
 
 # class ExtraBigFlagMixin:

--- a/src/django_enum/query.py
+++ b/src/django_enum/query.py
@@ -3,7 +3,7 @@ Specialized has_any and has_all query lookups for flag enumerations.
 """
 
 # from django.core.exceptions import FieldError
-from django.db.models.lookups import Exact
+from django.db.models.lookups import Exact, Lookup
 
 # from django_enum.utils import get_set_bits
 
@@ -75,26 +75,23 @@ class HasAllFlagsLookup(Exact):
 #         return lhs_sql, lhs_params
 
 
-class HasAnyFlagsLookup(HasAllFlagsLookup):
+class HasAnyFlagsLookup(Lookup):
     """
-    Extend Exact lookup to support lookup on has any flags. This bitwise ANDs
-    the column with the lookup value and checks that the result is greater
-    than zero.
+    Query whether the left-hand side has any of the bit flags on the right-hand
+    side. This lookup bitwise ANDs the left-hand side with the right-hand side
+    and checks that the result is not equal to zero.
     """
 
     lookup_name = "has_any"
 
-    def process_rhs(self, compiler, connection):
-        rhs_sql, rhs_params = super().process_rhs(compiler, connection)
-        rhs_params = list(rhs_params) if isinstance(rhs_params, tuple) else rhs_params
-        if rhs_params:
-            rhs_params[0] = 0
-        else:
-            rhs_sql = "0"
-        return rhs_sql, rhs_params
-
-    def get_rhs_op(self, connection, rhs):
-        return connection.operators["gt" if self.rhs else "exact"] % rhs
+    def as_sql(self, compiler, connection):
+        lhs_sql, lhs_params = self.process_lhs(compiler, connection)
+        rhs_sql, rhs_params = self.process_rhs(compiler, connection)
+        return (
+            f"BITAND({lhs_sql}, {rhs_sql}) <> 0"
+            if connection.vendor == "oracle"
+            else f"{lhs_sql} & {rhs_sql} <> 0"
+        ), [*lhs_params, *rhs_params]
 
 
 # class HasAnyFlagsExtraBigLookup(

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -184,8 +184,14 @@ class FlagTests(TestCase):
             cont8 = self.MODEL_CLASS.objects.filter(
                 **{f"{field}__has_all": EnumClass(0)}
             )
-            self.assertEqual(cont8.count(), empties[field])
+            self.assertEqual(
+                cont8.count(),
+                self.MODEL_CLASS.objects.filter(**{f"{field}__isnull": False}).count(),
+            )
             self.assertIn(empty, cont8)
+            self.assertIn(obj, cont8)
+            self.assertIn(obj2, cont8)
+            self.assertIn(obj3, cont8)
 
             cont9 = self.MODEL_CLASS.objects.filter(**{field: EnumClass(0)})
             self.assertEqual(cont9.count(), empties[field])

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -179,8 +179,7 @@ class FlagTests(TestCase):
             cont7 = self.MODEL_CLASS.objects.filter(
                 **{f"{field}__has_any": EnumClass(0)}
             )
-            self.assertEqual(cont7.count(), empties[field])
-            self.assertIn(empty, cont7)
+            self.assertEqual(cont7.count(), 0)
 
             cont8 = self.MODEL_CLASS.objects.filter(
                 **{f"{field}__has_all": EnumClass(0)}


### PR DESCRIPTION
- `flags__has_any=0` should be considered vacuously false: among an empty set of flags, it is not possible for at least one flag to be set.
- `flags__has_all=0` should be considered vacuously true (when `flags` is non-NULL): among an empty set of flags, all zero of these flags will be set.

These behaviors correctly follow from the bitwise AND implementation without an extra case. A user who wanted the previous incorrect behavior would have written `flags=0` rather than `flags__has_any=0` or `flags__has_all=0`.

`<> 0` makes more sense logically than `> 0`, and is important if we allow using the sign bit as a flag in the future (or via custom subclassing):

- #197

Simplify the implementations to avoid subclassing the unrelated `Exact` lookup.